### PR TITLE
Add gRPC auto-generation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,2 @@
+//go:generate protoc -I checker/ checker.proto --go_out=plugins=grpc:checker
+package deckard


### PR DESCRIPTION
Add `go generate` command to auto-generate gRPC code from protobuf spec.

Resolves #1 .