### PR TITLE
Add bare Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:18.04
+
+ADD bin/deckard-linux-amd64 /usr/bin/deckard
+
+ENTRYPOINT ["/usr/bin/deckard", "serve"]


### PR DESCRIPTION
Add Dockerfile for building a deckard server Docker image. This
currently looks for the bin in `bin/deckard-linux-amd64`.

Resolves #2 .
