### PR TITLE
Add spf13.Viper for envvar reading

### DIFF
--- a/cmd/server/command/command.go
+++ b/cmd/server/command/command.go
@@ -2,10 +2,12 @@ package command
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type Command struct {
 	Root *cobra.Command
+	*viper.Viper
 }
 
 func New() *Command {
@@ -13,13 +15,16 @@ func New() *Command {
 		Root: &cobra.Command{
 			Use: "deckard",
 		},
+		Viper: viper.New(),
 	}
 
 	c.Root.AddCommand(
 		c.NewServeCommand(),
 	)
 
-	c.setupFlags()
+	c.SetEnvPrefix("DECKARD")
+	c.AutomaticEnv()
+
 	return c
 }
 
@@ -29,7 +34,4 @@ func (c *Command) run(cmd *cobra.Command, args []string) error {
 
 func (c *Command) Execute() error {
 	return c.Root.Execute()
-}
-
-func (c *Command) setupFlags() {
 }

--- a/cmd/server/command/serve.go
+++ b/cmd/server/command/serve.go
@@ -16,37 +16,41 @@ const (
 )
 
 type ServeCommand struct {
-	root *Command
+	// Command is the parent command, which is where the Viper
+	// configuration is. Without an embedded Command, we would need some
+	// extra work to have Viper-bound flags and envvars.
+	*Command
 
 	listenAddr   string
 	publicAddr   string
-	writeTimeout time.Duration
 	readTimeout  time.Duration
+	writeTimeout time.Duration
 }
 
 func (c *Command) NewServeCommand() *cobra.Command {
-	s := &ServeCommand{root: c}
+	s := &ServeCommand{Command: c}
 	serveCmd := &cobra.Command{
 		Use:   "serve",
 		Short: "serve a deckard HTTP server",
 		RunE:  s.run,
 	}
 
-	serveCmd.Flags().StringVarP(&s.listenAddr, "addr", "a", defaultListenAddr, "address for deckard server to listen on")
-	serveCmd.Flags().DurationVarP(&s.writeTimeout, "timeout-write", "", defaultWriteTimeout, "timeout duration for write requests")
-	serveCmd.Flags().DurationVarP(&s.readTimeout, "timeout-read", "", defaultReadTimeout, "timeout duration for read requests")
+	serveCmd.Flags().String("addr", defaultListenAddr, "address for deckard server to listen on")
+	serveCmd.Flags().Duration("timeout-read", defaultReadTimeout, "timeout duration for read requests")
+	serveCmd.Flags().Duration("timeout-write", defaultWriteTimeout, "timeout duration for write requests")
+	s.BindPFlags(serveCmd.Flags())
 
 	return serveCmd
 }
 
 func (c *ServeCommand) run(cmd *cobra.Command, args []string) error {
 	dsrv := server.New(
-		server.ListenAddr(c.listenAddr),
-		server.WriteTimeout(c.writeTimeout),
-		server.ReadTimeout(c.readTimeout),
+		server.ListenAddr(c.GetString("addr")),
+		server.WriteTimeout(c.GetDuration("timeout-write")),
+		server.ReadTimeout(c.GetDuration("timeout-read")),
 	)
 
-	log.Printf("serving deckard on %s", c.listenAddr)
+	log.Printf("serving deckard on %s", c.GetString("addr"))
 	log.Fatal(dsrv.ListenAndServe())
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang/protobuf v1.3.1
 	github.com/gorilla/mux v1.7.3
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/viper v1.3.2
 	golang.org/x/net v0.0.0-20190522155817-f3200d17e092 // indirect
 	google.golang.org/grpc v1.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -6,6 +7,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -30,6 +32,7 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
@@ -42,7 +45,9 @@ github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -65,6 +70,7 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.21.0 h1:G+97AoqBnmZIT91cLG/EkCoK9NSelj64P8bOHHNmGn0=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Add spf13.Viper for optionally reading command-line flags from
environment variables instead. This slightly refactors some of the logic
of the Command struct, but does so for readability.

Resolves #3 .